### PR TITLE
chore: migrate action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ outputs:
     description: 'Whether tests eventually passed (true/false)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## What

Bump the action runtime in `action.yml` from `node20` to `node24`.

```diff
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
```

## Why

GitHub has deprecated Node 20 on Actions runners — the default is now Node 24. Every workflow that uses `itznotabug/php-retry` currently prints:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

(see the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Declaring `node24` removes the warning and runs on the runner's default runtime.

## Compatibility

- `dist/index.js` is produced by `bun build ./src/index.ts --target node` with no Node-version pin, so the emitted CJS bundle is forward-compatible.
- Runtime deps are `@actions/core`, `@actions/exec`, `@actions/github`, `fast-xml-parser`, `tree-kill` — none require Node 20-specific behavior; all are supported on Node 24.
- No source or `dist` rebuild needed; only the runtime declaration changes.